### PR TITLE
Add example: Bencode Parser

### DIFF
--- a/examples/bencoder/bencoder.ml
+++ b/examples/bencoder/bencoder.ml
@@ -79,3 +79,5 @@ let%test "bencoding homogeneous list" =
 let%test "bencoding dictionaries" =
   test_parser_ok b_dict "d3:foo3:bar4:spami42ee"
     (Dict [ ("foo", Str "bar"); ("spam", Num 42) ])
+
+let%test "bencoding negative int" = test_parser_ok integer "i-1e" (-1)

--- a/examples/bencoder/bencoder.ml
+++ b/examples/bencoder/bencoder.ml
@@ -38,29 +38,24 @@ let byte_string =
   char ':' *> take n
 
 let integer = bracket (char 'i') number (char 'e')
+let b_integer = lift num integer
+let b_byte_string = lift str byte_string
 
-(* Do we really need to fail if the keys are not sorted? Doesn't seem like a
-   responsibility of the parser. *)
-let sorted_keys pairs =
-  let keys = List.map fst pairs in
-  if sorted keys then pure pairs else fail "not sorted"
-
-let rec bvalue input = (bint <|> bstring <|> blist <|> bdict) input
-and bint = lift num integer
-and bstring = lift str byte_string
+let rec b_value input =
+  (b_integer <|> b_byte_string <|> b_list <|> b_dict) input
 
 (* XXX: Parse [t list] instead of [Lizt]? *)
-and blist input =
-  let p = bracket (char 'l') (many bvalue) (char 'e') in
+and b_list input =
+  let p = bracket (char 'l') (many b_value) (char 'e') in
   lift lizt p input
 
 (* Can we do something about [lift _ p input] pattern (looks ugly)? *)
 
 (* XXX: Parse [(string * t) list] instead of [Dict]? *)
-and bdict input =
+and b_dict input =
   let entry =
     let* key = byte_string in
-    let* value = bvalue in
+    let* value = b_value in
     pure (key, value)
   in
   let p = bracket (char 'd') (many entry) (char 'e') in
@@ -68,21 +63,21 @@ and bdict input =
 
 (* TODO: Improve tests *)
 let%test "bencoding int" =
-  "i42e" |> Input.create |> bvalue |> Result.map fst = Ok (Num 42)
+  "i42e" |> Input.create |> b_value |> Result.map fst = Ok (Num 42)
 
 let%test "bencoding string" =
-  "5:hello" |> Input.create |> bvalue |> Result.map fst = Ok (Str "hello")
+  "5:hello" |> Input.create |> b_value |> Result.map fst = Ok (Str "hello")
 
 let%test "bencoding homogeneous list" =
   "l4:spami42ee"
   |> Input.create
-  |> bvalue
+  |> b_value
   |> Result.map fst
   = Ok (Lizt [ Str "spam"; Num 42 ])
 
 let%test "bencoding dictionaries" =
   "d3:foo3:bar4:spami42ee"
   |> Input.create
-  |> bvalue
+  |> b_value
   |> Result.map fst
   = Ok (Dict [ ("foo", Str "bar"); ("spam", Num 42) ])

--- a/examples/bencoder/bencoder.ml
+++ b/examples/bencoder/bencoder.ml
@@ -1,0 +1,95 @@
+open Parzer
+open Parzer.Parser
+
+type t =
+  | Str of string
+  | Num of int
+  | Lizt of t list
+  | Dict of (string * t) list
+
+let num n = Num n
+let str s = Str s
+let lizt l = Lizt l
+let dict d = Dict d
+
+let is_digit = function
+  | '0' .. '9' -> true
+  | _ -> false
+
+let string_of_chars chars = chars |> List.to_seq |> String.of_seq
+let num_of_chars chars = chars |> string_of_chars |> int_of_string_opt
+
+let number =
+  is_digit |> sat_char |> many |> lift num_of_chars >>= function
+  | Some n -> pure n
+  | None -> fail "not a number"
+
+let rec bvalue input = (bint <|> bstring <|> blist <|> bdict) input
+and bint = bracket (char 'i') number (char 'e') |> lift num
+and bstring' = number >>= fun n -> char ':' *> take n
+and bstring input = (bstring' |> lift str) input
+
+and blist input =
+  (bracket (char 'l') (many bvalue) (char 'e') |> lift lizt) input
+
+and key_value input =
+  (let* key = bstring' in
+   let* value = bvalue in
+   pure (key, value))
+    input
+
+and sorted = function
+  | [] -> true
+  | _ :: t as keys ->
+      t
+      |> List.to_seq
+      |> Seq.zip (List.to_seq keys)
+      |> Seq.for_all (fun (a, b) -> a <= b)
+
+and bdict input =
+  (bracket (char 'd')
+     ( many key_value >>= fun pairs ->
+       if pairs |> List.map fst |> sorted then pure pairs else fail "not sorted"
+     )
+     (char 'e')
+  |> lift dict)
+    input
+
+let%test "bencoding int" =
+  "i42e" |> Input.create |> bvalue |> Result.map fst = Ok (Num 42)
+
+let%test "bencoding string" =
+  "5:hello" |> Input.create |> bvalue |> Result.map fst = Ok (Str "hello")
+
+let%test "bencoding homogeneous list" =
+  "l4:spami42ee"
+  |> Input.create
+  |> bvalue
+  |> Result.map fst
+  = Ok (Lizt [ Str "spam"; Num 42 ])
+
+let%test "bencoding dictionaries" =
+  "d3:foo3:bar4:spami42ee"
+  |> Input.create
+  |> bvalue
+  |> Result.map fst
+  = Ok (Dict [ ("foo", Str "bar"); ("spam", Num 42) ])
+
+(* This is failing because the error string is different.
+   Although, it is as expected when run from [utop]. I suspect that this has
+   something to do with the preprocessor. The error is as follows:
+
+   File "examples/bencoder/dune", line 4, characters 1-15:
+   4 |  (inline_tests)
+        ^^^^^^^^^^^^^^
+   Predicate not satisfied
+   File "examples/bencoder/bencoder.ml", line 89, characters 0-208: bencoding unsorted keys is false.
+
+   FAILED 1 / 5 tests *)
+let%test "bencoding unsorted keys" =
+  match
+    "d4:spami42e3:foo3:bare" |> Input.create |> bvalue |> Result.map fst
+  with
+  | Error "not sorted" -> true
+  | Error e -> print_endline e; false
+  | _ -> false

--- a/examples/bencoder/bencoder.ml
+++ b/examples/bencoder/bencoder.ml
@@ -27,17 +27,18 @@ let sorted = function
       |> Seq.zip (List.to_seq keys)
       |> Seq.for_all (fun (a, b) -> a <= b)
 
-(* TODO: -ve numbers *)
-let number =
-  is_digit |> sat_char |> many |> lift num_of_chars >>= function
-  | Some n -> pure n
-  | None -> fail "not a number"
+module Number = struct
+  let whole =
+    is_digit |> sat_char |> many |> lift num_of_chars >>= function
+    | Some n -> pure n
+    | None -> fail "not a number"
 
-let byte_string =
-  let* n = number in
-  char ':' *> take n
+  let negative = char '-' >>= Fun.const whole >>= fun n -> pure (-n)
+end
 
-let integer = bracket (char 'i') number (char 'e')
+let byte_string = Number.whole >>= fun n -> char ':' *> take n
+
+let integer = bracket (char 'i') Number.(whole <|> negative) (char 'e')
 let b_integer = lift num integer
 let b_byte_string = lift str byte_string
 

--- a/examples/bencoder/bencoder.ml
+++ b/examples/bencoder/bencoder.ml
@@ -41,6 +41,7 @@ let integer = bracket (char 'i') number (char 'e')
 let b_integer = lift num integer
 let b_byte_string = lift str byte_string
 
+(* TODO: Improve error messages *)
 let rec b_value input =
   (b_integer <|> b_byte_string <|> b_list <|> b_dict) input
 

--- a/examples/bencoder/dune
+++ b/examples/bencoder/dune
@@ -1,0 +1,6 @@
+(library
+ (name bencoder)
+ (libraries parzer)
+ (inline_tests)
+ (preprocess
+  (pps ppx_inline_test)))

--- a/lib/input.ml
+++ b/lib/input.ml
@@ -16,7 +16,7 @@ let to_string { buffer; offset; len } =
   String.sub buffer offset (len - offset) 
 
 let take n { buffer; offset; len } = 
-  if offset + n >= len
+  if offset + n > len
     then Error "Reached end of input"
     else Ok (String.sub buffer offset n)
 

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -92,6 +92,12 @@ let string s : string t =
         else Error (Printf.sprintf "Expected %s." s)
     | Error _ as err -> err
 
+let take n : string t =
+  fun input ->
+    match Input.take n input with
+    | Ok s -> Ok (s, Input.advance_by n input)
+    | Error _ as err -> err
+
 let rec many (p : 'a t) : 'a list t =
   let many' =
     p >>= fun x ->

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -89,8 +89,9 @@ let take n : string t =
     | Error _ as err -> err
 
 let string s : string t =
-  let* prefix = take (String.length s) in
-  if prefix = s then pure s else fail (Printf.sprintf "Expected %s." s)
+  take (String.length s) >>= function
+  | prefix when prefix = s -> pure s
+  | _ -> fail (Printf.sprintf "Expected %s." s)
 
 let rec many (p : 'a t) : 'a list t =
   let many' =

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -19,6 +19,7 @@ module Monad = struct
     | Error _ as err -> err
 
   let ( >>= ) = bind
+  let ( let* ) = bind
 
   let ( <* ) p q = 
     p >>= fun pout ->

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -62,6 +62,8 @@ module Alternative = struct
     | (Ok _ as p_out), _ -> p_out
     | _, (Ok _ as q_out) -> q_out
     | p_error, _ -> p_error
+
+  let ( <|> ) = or'
 end
 
 include Monad

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -82,21 +82,15 @@ let sat_char pred =
 
 let char c : char t = sat_char (fun x -> x = c)
 
-let string s : string t =
-  let slen = String.length s in
-  fun input ->
-    match Input.take slen input with
-    | Ok prefix ->
-        if prefix = s then
-          Ok (prefix, Input.advance_by slen input)
-        else Error (Printf.sprintf "Expected %s." s)
-    | Error _ as err -> err
-
 let take n : string t =
   fun input ->
     match Input.take n input with
     | Ok s -> Ok (s, Input.advance_by n input)
     | Error _ as err -> err
+
+let string s : string t =
+  let* prefix = take (String.length s) in
+  if prefix = s then pure s else fail (Printf.sprintf "Expected %s." s)
 
 let rec many (p : 'a t) : 'a list t =
   let many' =


### PR DESCRIPTION
Adds a bencode parser.

Makes a few changes to the library:
- Fixes an OBOE in `Input.take`
- Defines a monadic let operator
- Adds a combinator to read a string of some length
